### PR TITLE
Release 0.1.0 — data pump, integration tests, and documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
 
-## [Unreleased]
+## [0.1.0] - 2026-02-24
 
 ### Added
 - `quelay-domain`: transport traits (`QueLayStream`, `QueLaySession`, `QueLayTransport`)
@@ -16,13 +16,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - `quelay-domain`: `DrrScheduler` — Deficit Round Robin with strict C2I priority
 - `quelay-domain`: `QueLayHandler` callback trait with default no-op implementations
 - `quelay-domain`: `StreamMeta`, `TransferProgress`, `Direction` types
-- `quelay-link-sim`: `LinkSimTransport` and `LinkSimSession` with `connected_pair()`
-- `quelay-link-sim`: `LinkSimConfig` with presets (`perfect`, `degraded`, `outage_60s`)
-- `quelay-link-sim`: `LinkSimStream` implementing `AsyncRead + AsyncWrite`
-- `quelay-link-sim`: `TokenBucket` — wall-clock token bucket for BW cap enforcement
 - `quelay-quic`: QUIC transport via `quinn` — TLS, self-signed cert generation and pinning
 - `quelay-thrift`: Thrift C2I and callback service — IDL, generated stubs, wire↔domain mapping
 - `quelay-agent`: relay daemon with Thrift C2I, `SessionManager`, exponential backoff
   reconnection (1 s → 30 s cap), 6-byte wire framing + JSON stream metadata
 - `quelay-agent`: `ci-smoke-test.sh` — two-agent QUIC handshake smoke test (~1 s)
 - GitHub Actions CI: fmt check, clippy `-D warnings`, unit tests, smoke test on PR to main
+
+### Added (data pump + integration test suite)
+- `quelay-agent`: full uplink/downlink data pump (`active_stream.rs`) with `SpoolBuffer`
+  — three-pointer spool (`A`/`Q`/`T`) enabling lossless resume across link outages
+- `quelay-agent`: `RateLimiter` — timer-task-based bandwidth cap; interval clamped to
+  5–100 ms, targeting 8 chunks per tick; survives link outages via `link_down()` /
+  `link_up(new_write_half)` without reconstruction
+- `quelay-agent`: bidirectional reconnect — `SessionManager` now handles both uplink and
+  downlink reconnect; `accept_loop` dispatches on 8-byte stream-open header
+  (`OP_NEW_STREAM` / `OP_RECONNECT`); downlink pump uses `bytes_written` for duplicate
+  detection and gap detection on replay
+- `quelay-agent`: 8-byte stream-open header + 10-byte chunk header wire protocol; version
+  field for forward-compatible rejection; JSON payload for `StreamHeader` /
+  `ReconnectHeader`
+- `quelay-agent`: dedicated ack-reader task (`WormholeMsg`) to prevent deadlock under QUIC
+  flow-control backpressure; `mpsc` channel decouples ack processing from the write pump
+- `quelay-agent`: `pending` queue in `SessionManager` — streams enqueued while the link is
+  down are re-issued in arrival order after reconnect via `drain_pending`
+- `quelay-agent`: `UplinkHandle` / `DownlinkHandle` — typed handles stored in
+  `active_uplinks` / `active_downlinks`; `restore_active` prunes completed handles on
+  reconnect
+- `quelay-agent`: `link_enable(bool)` on `SessionManagerHandle` — used by integration tests
+  and the `link_enable` Thrift C2I method to inject link-down/up events without restarting
+  agents
+- `quelay-agent/src/bin/e2e_test.rs`: integration test binary replacing legacy C++
+  `FTAClientEndToEndTest` and shell-script orchestration; four subcommands: `rate-limiter`,
+  `multi-file`, `drr`, `small-file-edge-cases`; SHA-256 per-transfer verification;
+  throughput reporting; all timing derived from agent-reported BW cap
+- `scripts/ci-integration-test.sh`: CI integration test script orchestrating `e2e_test`
+  across two BW configurations (100 Mbit/s and 10 Mbit/s); replaces `ci-e2e-test.sh`
+- `quelay-agent/src/bin/README.md`: full `e2e_test` design doc — CLI reference, subcommand
+  rationale, legacy test mapping, timing derivation, CI integration guide
+
+### Changed
+- `quelay-agent`: `SessionManager::run` spawns a sibling `accept_loop` task; `session_restored`
+  `Notify` re-arms the accept loop after each successful reconnect
+- `quelay-agent`: wire framing updated from 6-byte to 8-byte stream-open header; chunk
+  header extended from 6-byte to 10-byte (adds 8-byte `stream_offset` for spool replay)
+- `quelay-agent`: `TransportConfig` enum replaces the earlier transport argument threading
+  through `main.rs`, enabling reconnect without involving `main`
+
+### Fixed
+- `quelay-agent`: deadlock under QUIC flow-control backpressure eliminated by moving ack
+  reads to a dedicated task rather than interleaving with the write pump in a `select!`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,7 @@ We follow [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and
 | Lint         | `cargo clippy --workspace -- -D warnings` |
 | Unit tests   | `cargo test --workspace` |
 | Smoke test   | `./scripts/ci-smoke-test.sh` |
+| Integration  | `./scripts/ci-integration-test.sh` |
 | Build docs   | `cargo doc --workspace --no-deps --open` |
 | Regen Thrift | `./scripts/thrift-compile.sh` |
 

--- a/docs/contributing/ARCHITECTURE.md
+++ b/docs/contributing/ARCHITECTURE.md
@@ -3,19 +3,18 @@
 ## Crate Dependency Graph
 
 ```
-quelay-thrift   ──┐
-quelay-quic     ──┼──► quelay-domain
-quelay-link-sim ──┘
+quelay-thrift ──┐
+quelay-quic   ──┼──► quelay-domain
 
 quelay-agent   ──► quelay-domain, quelay-thrift, quelay-quic
-quelay-example ──► quelay-domain, quelay-thrift, quelay-quic, quelay-link-sim
+quelay-example ──► quelay-domain, quelay-thrift, quelay-quic
 ```
 
 `quelay-domain` has no intra-workspace dependencies. The library crates
-(`quelay-thrift`, `quelay-quic`, `quelay-link-sim`) depend only on
-`quelay-domain` and never on each other. `quelay-agent` and
-`quelay-example` are binaries that compose the library crates; they sit
-outside the library dependency graph and are not published.
+(`quelay-thrift`, `quelay-quic`) depend only on `quelay-domain` and never on
+each other. `quelay-agent` and `quelay-example` are binaries that compose the
+library crates; they sit outside the library dependency graph and are not
+published.
 
 ## quelay-domain — The Domain Model
 
@@ -39,27 +38,33 @@ External clients (Rust / C++ / Python)
             │ Apache Thrift C2I
         quelay-thrift service handlers
             │
-    Quelay session manager
-    (reconnection, spooling, UUID mapping)
+    SessionManager
+    (reconnection, in-memory spool, UUID mapping)
             │
-    DrrScheduler  ←→  AIMD Pacer (TODO)
+    DrrScheduler  ←→  RateLimiter (timer-task BW cap)
             │
     QueLayTransport trait
-     ├── QuicTransport     (quelay-quic)
-     └── LinkSimTransport  (quelay-link-sim)
+     └── QuicTransport  (quelay-quic)
 ```
 
 ## Bandwidth Management
 
-Quelay uses **AIMD within a rate cap**:
+Each uplink stream is metered by a `RateLimiter` — a dedicated timer task that
+wakes on a computed interval (clamped to 5–100 ms), drains up to a byte budget
+from an mpsc queue, and discards unused budget:
 
-- The operator configures a maximum bandwidth (e.g. 20 % of 10 Mbit/s).
-- The AIMD pacer (not yet implemented) gates bytes fed to the DRR
-  scheduler each tick.
-- When the link degrades, AIMD backs off naturally — no operator
-  intervention needed.
-- QUIC's built-in congestion control is left enabled but the pacer cap
-  sits above it.
+```text
+bytes_per_tick = CHUNKS_PER_TICK × CHUNK_SIZE   (target: 8 chunks per tick)
+interval_ms    = bytes_per_tick × 1000 / rate_bytes_per_sec
+                 (clamped to [5 ms, 100 ms])
+budget_bytes   = rate_bytes_per_sec × interval_ms / 1000
+```
+
+The operator configures a hard ceiling via `--bw-cap-mbps`. QUIC's built-in
+congestion control operates below that ceiling and handles packet-loss backoff
+transparently — no application-layer AIMD is needed. The `RateLimiter` survives
+link outages: `link_down()` drains and discards queued chunks; `link_up(new_tx)`
+installs a fresh write half without reconstructing the limiter.
 
 ## Priority and Scheduling
 
@@ -71,29 +76,82 @@ scheduled fairly by `DrrScheduler` using Deficit Round Robin.
 internal scheduling weight. The scheduler maps one to the other and
 may adjust quanta dynamically (e.g. when streams join or leave).
 
-## Session Resilience *(planned)*
+## Session Resilience
 
 The logical session layer sits above QUIC. When the QUIC connection
 drops (link outage), Quelay:
 
 1. Transitions `LinkState` to `Failed`.
-2. Spools incoming data locally.
+2. Pauses active uplink pumps (the rate limiter timer task drains and
+   discards queued chunks, then blocks waiting for `LinkUp`).
 3. Reconnects to the remote endpoint with exponential backoff (1 s → 30 s cap).
-4. Resumes each in-flight stream from the last ACK'd byte, identified
-   by UUID.
-5. Transitions `LinkState` back to `Normal`.
+4. Calls `restore_active` — opens a fresh QUIC stream per in-flight uplink,
+   writes a `ReconnectHeader` with `replay_from = bytes_acked`, and delivers
+   the stream to the pump via channel.  The pump replays `A..T` from its
+   `SpoolBuffer` and resumes.
+5. Calls `drain_pending` — re-issues streams that were queued while the link
+   was down.
+6. Notifies the `accept_loop` via `session_restored` so inbound reconnect
+   streams from the peer are dispatched to the correct downlink pumps.
+7. Transitions `LinkState` back to `Normal`.
+
+The spool is fixed at 1 MiB (`SPOOL_CAPACITY`), sized to cover data buffered in
+QUIC plus at most one in-flight packet on the receiver side. Once the receiver acks
+data (after writing it to the client socket), those bytes are released from the
+spool and never need to be replayed. If the spool fills during a prolonged outage,
+back-pressure is applied to the sender's TCP read socket — the writer blocks rather
+than losing data. Moving `SPOOL_CAPACITY` to a startup config option is a planned
+trivial refactor; disk spooling is deferred until a real-time SIGINT use case
+requires non-blocking writers.
+
+## SpoolBuffer — Uplink Spool Design
+
+Each uplink stream maintains a fixed-size in-memory ring buffer (`SpoolBuffer`)
+shared between two decoupled sub-tasks:
+
+- **TCP reader** — reads bytes from the local client's ephemeral TCP socket and
+  pushes them into the spool (`T` advances). Blocks when the spool is full
+  (back-pressure to the sender).
+- **QUIC pump** — drains bytes from the spool into the metered QUIC stream
+  (`Q` advances). On link failure it rewinds `Q = A` and waits for a fresh stream.
+  On reconnect it replays `A..T` on the new stream and resumes.
+
+```text
+spool [capacity: SPOOL_CAPACITY = 1 MiB]
+[.......................................................]
+ ^               ^                                     ^
+ A               Q                                     T
+ bytes_acked     next_quic_write      head (next TCP write)
+```
+
+`A` advances when `WormholeMsg::Ack { bytes_received }` arrives from the
+receiver (sent after it writes to its client socket). Acked bytes are released
+from the spool immediately — they will never need to be replayed.
+
+Invariants: `A ≤ Q ≤ T`, `T − A ≤ SPOOL_CAPACITY`.
+
+The spool depth is sized to absorb data buffered inside QUIC plus at most one
+in-flight packet on the receiver side — estimated at ~512 KiB, rounded up to
+1 MiB for headroom. Moving the constant to `config.rs` for startup configuration
+is a planned trivial refactor.
 
 ## quelay-agent — The Daemon Binary
 
 `quelay-agent` is the deployable process that bridges local Thrift C2I
-clients to a remote Quelay peer over QUIC. It sits at the top two layers
-of the diagram above: the Thrift service handlers and the session manager
-beneath them. Internally the synchronous Thrift handler and the async
-session loop communicate through an `mpsc` channel so neither half needs
-to know about the other's runtime.
+clients to a remote Quelay peer over QUIC. It covers all layers of the
+diagram above: the Thrift service handlers, `SessionManager`, data pumps,
+and rate limiter.
 
-`quelay-example` exercises the same library crates in-process using
-`quelay-link-sim`, without needing two running processes or a real network.
+The synchronous Thrift handler and the async session loop communicate
+through an `mpsc` channel so neither half needs to know about the other's
+runtime. Each uplink stream is managed by an `ActiveStream` task that reads
+from an ephemeral TCP port, spools bytes via `SpoolBuffer`, and meters them
+into the QUIC stream through `RateLimiter`. Downlink streams are the mirror:
+the agent accepts QUIC streams, reads chunks, and writes them to an ephemeral
+TCP port for the local client.
+
+`quelay-example` provides demos and in-process smoke checks using
+`quelay-quic` directly, without requiring a full two-agent setup.
 
 See [`quelay-agent/README.md`](../../quelay-agent/README.md) for
 operator usage, CLI reference, TLS/cert-pinning notes, and a detailed

--- a/docs/contributing/LOCAL_TESTING.md
+++ b/docs/contributing/LOCAL_TESTING.md
@@ -21,7 +21,17 @@ cargo test --workspace
 ./scripts/local-test.sh
 ```
 
-This runs format, lint, and tests in order and stops on first failure.
+This runs format, lint, unit tests, smoke test, and integration tests in order
+and stops on first failure.
+
+## Integration Tests Only
+
+```bash
+./scripts/ci-integration-test.sh
+```
+
+Starts two agents, runs all `e2e_test` subcommands across two BW configurations,
+and stops the agents. Takes ~2 minutes.
 
 ## Checking a Single Crate
 

--- a/docs/contributing/QUICK_START.md
+++ b/docs/contributing/QUICK_START.md
@@ -30,6 +30,16 @@ cargo test --workspace
 Starts two `quelay-agent` instances on loopback, validates QUIC handshake
 and C2I reachability end-to-end in ~1 second.
 
+## Run the Integration Test Suite
+
+```bash
+./scripts/ci-integration-test.sh
+```
+
+Runs the full `e2e_test` suite across two BW configurations (100 Mbit/s and
+10 Mbit/s). Covers file transfers, link outage + reconnect, DRR priority,
+and framing edge cases. Requires ~2 minutes on a developer workstation.
+
 ## Run a Specific Test
 
 ```bash

--- a/quelay-agent/README.md
+++ b/quelay-agent/README.md
@@ -1,6 +1,8 @@
 # quelay-agent
 
-The deployable Quelay relay daemon. It bridges local Thrift C2I clients (C++, Rust, Python — anything that speaks Apache Thrift) to a remote Quelay peer over a QUIC link.
+The deployable Quelay relay daemon. It bridges local Thrift C2I clients (C++,
+Rust, Python — anything that speaks Apache Thrift) to a remote Quelay peer over
+a QUIC link.
 
 ## Quick start
 
@@ -34,67 +36,147 @@ quelay-agent --agent-endpoint 127.0.0.1:9091 server
 There is no single flag that prints the full subcommand tree; use `-h` on
 each level as needed.
 
+### Top level `quelay-agent` usage message
+
 ```
-cargo run -qp quelay-agent -- --help
+cargo run -q --bin quelay-agent -- --help
 Quelay relay daemon
 
 Usage: quelay-agent [OPTIONS] <COMMAND>
 
 Commands:
-  server  Listen for an incoming QUIC connection (satellite / ground station in server role for this session)
+  server  Listen for an incoming QUIC connection (satellite ground station or
+          server role for this session)
   client  Connect to a remote Quelay agent (example: 192.168.1.10:5000)
   help    Print this message or the help of the given subcommand(s)
 
 Options:
       --agent-endpoint <AGENT_ENDPOINT>
-          TCP address on which to expose the local Thrift C2I interface.
-          Quelay example clients and other local C2I consumers connect here
+          TCP address on which to expose the local Thrift C2I interface. Quelay
+          example clients and other local C2I consumers connect here
           [default: 127.0.0.1:9090]
+
+      --spool-dir <SPOOL_DIR>
+          Directory used to spool stream data when the link is down.
+          Created automatically if it does not exist.
+          [default: /tmp/quelay-spool]
+
+      --bw-cap-mbps <BW_CAP_MBPS>
+          Uplink bandwidth cap in Mbit/s.
+          
+          Applied by the token bucket rate limiter on every QUIC write. Set to 0
+          (default) to disable rate limiting entirely.
+          
+          Example: `--bw-cap-mbps 10` caps at 10 Mbit/s (1.25 MB/s).
+          [default: 0]
+
+      --chunk-size-bytes <CHUNK_SIZE_BYTES>
+          Chunk payload size in bytes written to the QUIC stream.
+          
+          Controls spool granularity and ack frequency.  Must be ≤ 65535 (u16
+          max — the wire field width).  Defaults to 16 KiB.
+          
+          The integration test binary sets this to 1024 for
+          `small-file-edge-cases` to reproduce the legacy FTA block size and
+          exercise multi-block framing boundaries.
+          [default: 16384]
+
+      --spool-capacity-bytes <SPOOL_CAPACITY_BYTES>
+          In-memory spool capacity per uplink stream in bytes.
+          
+          The spool absorbs bursts during link outages.  When full the TCP
+          reader pauses (back-pressure to the client).  The link-outage test in
+          `e2e_test` derives its link-down window from this value. Defaults to 1 MiB.
+          [default: 1048576]
+
+  -N, --max-concurrent <MAX_CONCURRENT>
+          Maximum concurrent active streams (0 = unlimited).
+          
+          The DRR test sets this to 1 via the `set_max_concurrent` C2I call so
+          that queued streams are reordered by priority before activation. This
+          flag sets the startup default; the value can be changed live via
+          `set_max_concurrent`.
+          [default: 0]
+
   -h, --help
-          Print help
+          Print help (see a summary with '-h')
 ```
 
+### `quelay-agent` server usage message
+
 ```
-cargo run -qp quelay-agent -- server --help
-Listen for an incoming QUIC connection (satellite / ground station in server role for this session)
+cargo run -q --bin quelay-agent -- server --help
+Listen for an incoming QUIC connection (satellite ground station or server role
+for this session)
 
 Usage: quelay-agent server [OPTIONS]
 
 Options:
-      --bind <BIND>  UDP address to bind the QUIC endpoint on [default: 0.0.0.0:5000]
+      --bind <BIND>  UDP address to bind the QUIC endpoint on 
+                     [default: 0.0.0.0:5000]
   -h, --help         Print help
 ```
 
+### `quelay-agent` client usage message
+
 ```
-cargo run -qp quelay-agent -- client --help
+cargo run -q --bin quelay-agent -- client --help
 Connect to a remote Quelay agent (example: 192.168.1.10:5000)
 
 Usage: quelay-agent client [OPTIONS] --peer <PEER> --cert <CERT>
 
 Options:
       --peer <PEER>                UDP address of the remote agent's QUIC endpoint
-      --server-name <SERVER_NAME>  TLS server name — must match the name used when the server
-                                   generated its cert [default: quelay]
-      --cert <CERT>                Path to the server's self-signed cert DER file.
-                                   The server writes this at startup; copy it to the client
-                                   before launching
-  -h, --help                       Print help
+      --server-name <SERVER_NAME>  TLS server name — must match the name used
+                                   when the server generated its cert (default: "quelay")
+                                   [default: quelay]
+
+      --cert <CERT>                Path to the server's self-signed cert DER
+                                   file. The server writes this at startup; copy
+                                   it to the client before launching
+
+  -h, --help                       Print this help messsage
 ```
 
 ## TLS / certificate pinning
 
-The server generates a self-signed certificate at startup via `rcgen` and writes the DER-encoded cert to `quelay-server.der` in the working directory. The client pins this cert directly — there is no CA involved. Copy the file out-of-band before starting the client. The server name used during cert generation defaults to `"quelay"`; override with `--server-name` on the client if you generated with a different name.
+The server generates a self-signed certificate at startup via `rcgen` and writes
+the DER-encoded cert to `quelay-server.der` in the working directory. The client
+pins this cert directly — there is no CA involved. Copy the file out-of-band
+before starting the client. The server name used during cert generation defaults
+to `"quelay"`; override with `--server-name` on the client if you generated with
+a different name.
 
-## Internal structure
+## Internal structure (quelay-agent)
 
 ```
-main.rs          — CLI parsing, QUIC setup, wires the two halves together
-config.rs        — Clap structs (Config, Mode)
-agent.rs         — Agent: owns QueLaySession, async command loop
-thrift_srv.rs    — AgentHandler: sync Thrift handler, enqueues AgentCmds
+main.rs            — CLI parsing, QUIC setup, wires the two halves together
+config.rs          — Clap structs (Config, Mode)
+agent.rs           — Agent: owns SessionManagerHandle, async command loop
+thrift_srv.rs      — AgentHandler: sync Thrift handler, enqueues AgentCmds
+session_manager.rs — SessionManager: reconnection loop, pending queue, accept loop
+active_stream.rs   — Uplink/downlink data pumps, SpoolBuffer (three-pointer A/Q/T)
+rate_limiter.rs    — Timer-task-based BW cap; link_down / link_up without reconstruction
+framing.rs         — 8-byte stream-open header, 10-byte chunk header, read/write helpers
+callback.rs        — CallbackAgent: async Thrift callback push path
+bin/e2e_test.rs    — Quelay integration test binary
 ```
 
-The Thrift `TServer` manages its own pool of OS threads (up to the configured max); this is the synchronous Thrift runtime from the `thrift` crate, not tokio's `spawn_blocking` pool. The session is async and lives on the tokio runtime. Rather than exposing the session across that boundary, the two halves communicate through an `mpsc::channel`. `AgentHandler` holds a `tokio::runtime::Handle` and uses `Handle::block_on` to reach into the tokio runtime from the Thrift threads when it needs to enqueue a command or read shared state. The handler itself is intentionally thin — it validates and converts wire types, sends an `AgentCmd`, and returns. All `QueLaySession` calls happen in `Agent::run`.
+`TServer` is launched via `tokio::task::spawn_blocking`, which hands it to a
+blocking thread. From there the synchronous Thrift runtime manages its own
+per-connection OS threads. The session is async and lives on the tokio
+runtime. Rather than exposing the session across that boundary, the two halves
+communicate through an `mpsc::channel`. `AgentHandler` holds a
+`tokio::runtime::Handle` and uses `Handle::block_on` to reach into the tokio
+runtime from the Thrift threads when it needs to enqueue a command or read
+shared state. The handler itself is intentionally thin — it validates and
+converts wire types, sends an `AgentCmd`, and returns. All `SessionManager`
+calls happen in `Agent::run`.
+
+`TServer` is configured with a maximum of 10 threads, created on demand as C2I
+connections arrive — none are pre-spawned at startup. When a connection closes
+its thread exits, so under typical single-client usage only one Thrift thread is
+live at a time.
 
 ```
 Thrift OS threads                    tokio runtime
@@ -102,12 +184,13 @@ Thrift OS threads                    tokio runtime
 │  AgentHandler       │  AgentCmd   │  Agent               │
 │  (sync, per-call)   │ ──────────► │  (async, event loop) │
 │                     │   mpsc      │                      │
-│  maps wire↔domain   │             │  owns QueLaySession  │
+│  maps wire↔domain   │             │  owns SessionManager │
 │  Handle::block_on   │             │  drives QUIC streams │
 └─────────────────────┘             └──────────────────────┘
 ```
 
-`link_state` is shared as `Arc<Mutex<LinkState>>` so `get_link_state` can read the current value synchronously without crossing the channel.
+`link_state` is shared as `Arc<Mutex<LinkState>>` so `get_link_state` can read
+the current value synchronously without crossing the channel.
 
 ## Thrift C2I interface
 
@@ -118,21 +201,29 @@ The generated service trait is `QueLayAgentSyncHandler`. Methods currently handl
 
 | Method | Behaviour |
 |:-------|:----------|
-| `get_version` | Returns the IDL version string from `quelay-thrift`. |
+| `get_version`                        | Returns the IDL version string from `quelay-thrift`. |
 | `stream_start(uuid, info, priority)` | Enqueues a `StreamStart` command; returns queue position. |
-| `set_callback(endpoint)` | Registers the callback endpoint for async status pushes. Returns an error string if a callback is already registered — only one active callback is supported; a second call is rejected. |
-| `get_link_state` | Returns the current `LinkState` snapshot. |
+| `set_callback(endpoint)`             | Registers the callback endpoint for async status pushes. Returns an error string if a callback is already registered — only one active callback is supported; a second call is rejected. |
+| `get_link_state`                     | Returns the current `LinkState` snapshot. |
 
-The callback push path (`QueLayCallback`) is registered via `set_callback` but the outbound Thrift client is not yet wired — status callbacks are a no-op until the session manager iteration lands.
 
-## SessionManager Status
+## SessionManager
 
-The session manager layer — reconnection, UUID→stream remapping on reconnect, and spool-to-disk on `LinkState::Failed` — sits between `Agent` and the raw `QueLaySession`. Until it lands, `Agent` calls `open_stream` directly and a lost QUIC connection is fatal. See `docs/contributing/ARCHITECTURE.md` for the intended design.
+The `SessionManager` layer sits between `Agent` and the raw `QueLaySession`,
+handling reconnection, UUID→stream remapping on reconnect, and pending stream
+queuing during outages.
 
-The `SessionManager` layer now sits between `Agent` and the raw `QueLaySession`,
-handling reconnection, UUID→stream remapping on reconnect, and spool-to-disk on
-`LinkState::Failed`. Stream lifecycle management now flows through the session
-layer rather than directly through `open_stream`.
+Stream lifecycle management flows through the session layer:
+
+- `stream_start` opens a live QUIC stream immediately when the session is up,
+  or queues the request in `pending` when the link is down.
+- On reconnect, `restore_active` delivers fresh QUIC streams to all in-flight
+  uplink pumps; `drain_pending` re-issues queued streams in arrival order.
+- The inbound `accept_loop` sibling task dispatches on the stream-open opcode:
+  `OP_NEW_STREAM` spawns a new downlink pump; `OP_RECONNECT` delivers a fresh
+  stream to the existing downlink pump for replay and resume.
+- `link_enable(bool)` is available in non-production builds for integration
+  test injection of link-down/up events without restarting agents.
 
 See `docs/contributing/ARCHITECTURE.md` for the intended recovery model and
 design details.

--- a/quelay-agent/src/config.rs
+++ b/quelay-agent/src/config.rs
@@ -49,12 +49,6 @@ pub struct Config {
     #[arg(long, default_value = "127.0.0.1:9090")]
     pub agent_endpoint: SocketAddr,
 
-    /// Directory used to spool stream data when the link is down.
-    ///
-    /// Created automatically if it does not exist.
-    #[arg(long, default_value = "/tmp/quelay-spool")]
-    pub spool_dir: PathBuf,
-
     /// Uplink bandwidth cap in Mbit/s.
     ///
     /// Applied by the token bucket rate limiter on every QUIC write.

--- a/quelay-agent/src/main.rs
+++ b/quelay-agent/src/main.rs
@@ -109,9 +109,6 @@ async fn main() -> anyhow::Result<()> {
         "quelay-agent starting",
     );
 
-    fs::create_dir_all(&cfg.spool_dir)?;
-    info!(spool_dir = %cfg.spool_dir.display(), "spool directory ready");
-
     // Build the shared runtime config from startup CLI values.
     // AgentHandler writes to it; session manager reads it when starting streams.
     let runtime_cfg = Arc::new(std::sync::Mutex::new(RuntimeConfig::new(
@@ -180,7 +177,6 @@ async fn main() -> anyhow::Result<()> {
         initial_session,
         transport_cfg,
         link_state.clone(),
-        cfg.spool_dir.clone(),
         cb_tx.clone(),
         cfg.bw_cap_bps(),
     ));

--- a/quelay-agent/src/session_manager.rs
+++ b/quelay-agent/src/session_manager.rs
@@ -31,7 +31,6 @@
 
 use super::ActiveStream;
 use std::collections::HashMap;
-use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -179,11 +178,6 @@ pub struct SessionManager {
     /// Shared link state observable by `Agent` and the Thrift handler.
     link_state: Arc<Mutex<LinkState>>,
 
-    /// Spool directory.  Data is written here when the link is `Failed`.
-    /// Stubbed: directory is created but no data is written yet.
-    #[allow(dead_code)]
-    spool_dir: PathBuf,
-
     /// Sender handle to the [`CallbackAgent`] thread.
     ///
     /// Cloned into each [`ActiveStream`] task so it can fire lifecycle
@@ -211,7 +205,6 @@ impl SessionManager {
         session: QueLaySessionPtr,
         transport_cfg: TransportConfig,
         link_state: Arc<Mutex<LinkState>>,
-        spool_dir: PathBuf,
         cb_tx: CallbackTx,
         bw_cap_bps: Option<u64>,
     ) -> Self {
@@ -221,7 +214,6 @@ impl SessionManager {
             remote: Arc::new(Mutex::new(Some(remote))),
             transport_cfg: Mutex::new(transport_cfg),
             link_state,
-            spool_dir,
             cb_tx,
             bw_cap_bps,
             session_restored: Arc::new(Notify::new()),


### PR DESCRIPTION
Adds receiver-side reconnect across link outages, deficit round-robin stream scheduling, per-stream progress callbacks, and a structured Rust e2e test binary replacing the old shell-based CI tests.

Key changes:
- Wire protocol v2: OP_NEW_STREAM / OP_RECONNECT opcodes, ReconnectHeader, chunk header shrunk to 10 bytes
- Uplink pump redesigned with dedicated ack-reader task to eliminate select! deadlock under flow-control backpressure
- Downlink reconnect: DownlinkHandle with AtomicU64 bytes_written for gap validation; duplicate detection and partial-overlap trimming on replay
- Token bucket rate limiter replacing BandwidthGate; DRR scheduler for priority ordering
- StreamProgress callbacks fired every 1 MiB on both uplink and downlink
- e2e_test binary: rate-limiter, multi-file, drr, small-file-edge-cases subcommands with SHA-256 verification, BW utilization checks, and link-outage reconnect testing