### PR TITLE
chore: release 0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.1.3] - 2026-02-28
+
+### Changed
+- Refactored split up `e2e_test.rs` from a single 1400-line file
+
+### Fixed
+- `set_max_concurrent` C2I call was a no-op in `SessionManager`
+- `AckTask` did not notify `SessionManager` on stream completion
+- `enqueue()` returned the stream's sorted insertion rank
+
+### Added
+- Added full integration test for max-concurrent agent option
+
 ## [0.1.2] - 2026-02-26
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -662,7 +662,7 @@ dependencies = [
 
 [[package]]
 name = "quelay-agent"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -685,7 +685,7 @@ dependencies = [
 
 [[package]]
 name = "quelay-domain"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -698,7 +698,7 @@ dependencies = [
 
 [[package]]
 name = "quelay-example"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "quelay-quic"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "quelay-thrift"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "ordered-float 4.6.0",
  "quelay-domain",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version      = "0.1.2"
+version      = "0.1.3"
 edition      = "2021"
 license      = "MIT OR Apache-2.0"
 authors      = ["John Basrai"]


### PR DESCRIPTION
- Refactored split up `e2e_test.rs` from a single 1400-line file
- Added full integration test for max-concurrent agent option
- Fixed `set_max_concurrent` C2I call was a no-op in `SessionManager`