### PR TITLE
refactor: route LinkEnable through SessionCommand channel

### DIFF
--- a/quelay-agent/src/agent.rs
+++ b/quelay-agent/src/agent.rs
@@ -9,7 +9,7 @@ use tokio::sync::mpsc;
 
 // ---
 
-use super::{AgentCmd, SessionCommand, SessionCommandQueue, SessionManagerHandle};
+use super::{AgentCmd, SessionCommand, SessionCommandQueue};
 
 // ---------------------------------------------------------------------------
 // Agent
@@ -18,7 +18,6 @@ use super::{AgentCmd, SessionCommand, SessionCommandQueue, SessionManagerHandle}
 pub struct Agent {
     // ---
     cmd_rx: mpsc::Receiver<AgentCmd>,
-    sm: SessionManagerHandle,
     sm_cmd_tx: SessionCommandQueue,
 }
 
@@ -26,16 +25,8 @@ pub struct Agent {
 
 impl Agent {
     // ---
-    pub fn new(
-        cmd_rx: mpsc::Receiver<AgentCmd>,
-        sm_cmd_tx: SessionCommandQueue,
-        sm: SessionManagerHandle,
-    ) -> Self {
-        Self {
-            cmd_rx,
-            sm_cmd_tx,
-            sm,
-        }
+    pub fn new(cmd_rx: mpsc::Receiver<AgentCmd>, sm_cmd_tx: SessionCommandQueue) -> Self {
+        Self { cmd_rx, sm_cmd_tx }
     }
 
     // ---
@@ -65,7 +56,11 @@ impl Agent {
                 }
 
                 AgentCmd::LinkEnable(enabled) => {
-                    self.sm.link_enable(enabled).await;
+                    // Forward LE to SessionManagerHandle
+                    let _ = self
+                        .sm_cmd_tx
+                        .send(SessionCommand::LinkEnable(enabled))
+                        .await;
                 }
 
                 // RuntimeConfig is updated in-place by AgentHandler before

--- a/quelay-agent/src/bin/bw_cap_test/cic.rs
+++ b/quelay-agent/src/bin/bw_cap_test/cic.rs
@@ -1,6 +1,6 @@
 //! Cambat Information Center (CIC) — message types and dispatch loop.
 //!
-//! CIC is the center nerve center of `bw-cap-test`.  It owns:
+//! CIC is the central nerve center of `bw-cap-test`.  It owns:
 //! - Both agent C2I handles (sender + receiver)
 //! - The master dispatch map `HashMap<(uuid, Role), mpsc::Sender<TunerCmd>>`
 //! - The `Vec<TunerPair>` for coordinated shutdown

--- a/quelay-agent/src/main.rs
+++ b/quelay-agent/src/main.rs
@@ -109,7 +109,6 @@ pub use framing::{
     CHUNK_HEADER_LEN,
     CHUNK_SIZE,
 };
-pub(crate) use session_manager::SessionManagerHandle;
 pub(crate) use thrift_srv::AgentCmd;
 
 // ---------------------------------------------------------------------------
@@ -225,11 +224,9 @@ async fn main() -> anyhow::Result<()> {
     );
     let sm = Arc::new(sm);
 
-    let sm_handle = SessionManagerHandle::new(sm.clone());
-
     tokio::spawn(sm.run(sm_cmd_rx));
 
-    let agent = Agent::new(cmd_rx, sm_cmd_tx, sm_handle);
+    let agent = Agent::new(cmd_rx, sm_cmd_tx);
     tokio::spawn(agent.run());
 
     let rt = tokio::runtime::Handle::current();

--- a/quelay-agent/src/session_manager.rs
+++ b/quelay-agent/src/session_manager.rs
@@ -82,6 +82,7 @@ pub(crate) enum SessionCommand {
     /// Update the maximum number of concurrent active uplinks at runtime.
     /// `None` means unlimited (0 from the C2I layer maps to this).
     SetMaxConcurrent(Option<usize>),
+    LinkEnable(bool),
 }
 
 pub(crate) type SessionCommandQueue = mpsc::Sender<SessionCommand>;
@@ -551,6 +552,7 @@ impl SessionManager {
                     remote.send_queue_status(&self.cb_tx).await;
                 }
             }
+            SessionCommand::LinkEnable(enable) => self.link_enable(enable).await,
         }
     }
 
@@ -1016,40 +1018,5 @@ impl SessionManager {
             }
             alive
         });
-    }
-}
-
-// ---------------------------------------------------------------------------
-// SessionManagerHandle
-// ---------------------------------------------------------------------------
-
-/// Cheap clone handle used by `Agent` to submit commands without holding a
-/// lock across await points.
-#[derive(Clone)]
-pub(crate) struct SessionManagerHandle {
-    // ---
-    inner: Arc<SessionManager>,
-}
-
-// ---
-
-impl SessionManagerHandle {
-    // ---
-
-    /// Wrap an `Arc<SessionManager>` for use by `Agent`.
-    pub(crate) fn new(sm: Arc<SessionManager>) -> Self {
-        Self { inner: sm }
-    }
-
-    // ---
-
-    // -----------------------------------------------------------------------
-    // Test / debug — disabled in production builds
-    // -----------------------------------------------------------------------
-
-    /// Simulate a link failure (`enabled = false`) or allow reconnect
-    /// (`enabled = true`).
-    pub(crate) async fn link_enable(&self, enabled: bool) {
-        self.inner.link_enable(enabled).await;
     }
 }


### PR DESCRIPTION
* Remove `SessionManagerHandle`, which existed solely to call `link_enable()` directly on `Arc<SessionManager>`.
* Add `SessionCommand::LinkEnable` and dispatch it in `SessionManager::handle_cmd`, making all agent→session-manager communication uniform through the existing command queue.