### PR TITLE
feat: gate test/debug RPC hooks behind test-hooks feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - `scripts/link-sim-test.sh`: satellite link impairment integration test
   using Linux `tc netem` on a `veth` pair. Supports `loss`, `delay`, and
   `both` profiles. Results documented in `quelay-agent/README.md`.
+- `test-hooks` Cargo feature gate: `link_enable`, `set_max_concurrent`, and
+  `set_chunk_size_bytes` RPC handlers and their supporting code
+  (`SessionCommand::LinkEnable`, `SessionCommand::SetMaxConcurrent`,
+  `UplinkHandle::notify_link_down`, `link_down_tx`) are now compiled out
+  unless `--features test-hooks` is passed. Production builds are clean by
+  default.
+
+### Changed
+- `scripts/ci-integration-test.sh`: passes `--features test-hooks` when
+  building `quelay-agent` and `e2e-test` so the integration test hooks
+  remain active in CI.
+- Routed `LinkEnable` through `SessionCommand` channel, removing
+  `SessionManagerHandle` which existed solely to call `link_enable()`
+  directly on `Arc<SessionManager>`.
+
+---
 
 ## [0.1.3] - 2026-02-28
 
@@ -24,6 +40,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 - Added full integration test for max-concurrent agent option
+
+---
 
 ## [0.1.2] - 2026-02-26
 

--- a/quelay-agent/Cargo.toml
+++ b/quelay-agent/Cargo.toml
@@ -45,3 +45,6 @@ uninlined_format_args = "warn"
 unwrap_used           = "deny"
 expect_used           = "deny"
 panic                 = "deny"
+
+[features]
+test-hooks = []

--- a/quelay-agent/src/active_stream.rs
+++ b/quelay-agent/src/active_stream.rs
@@ -74,6 +74,8 @@ use quelay_thrift::FailReason;
 
 // ---
 
+#[cfg(feature = "test-hooks")]
+use super::RateCmd;
 use super::{
     // ---
     read_chunk,
@@ -84,7 +86,6 @@ use super::{
     CallbackCmd,
     CallbackTx,
     Chunk,
-    RateCmd,
     RateLimiter,
     WormholeMsg,
     ACK_INTERVAL,
@@ -278,6 +279,7 @@ pub struct UplinkHandle {
     ///
     /// Call `notify_link_down()` when `link_enable(false)` fires so the
     /// [`StreamPump`] rewinds `Q = A` and waits for a fresh write half.
+    #[cfg(feature = "test-hooks")]
     link_down_tx: Option<mpsc::Sender<RateCmd>>,
 }
 
@@ -295,6 +297,7 @@ impl UplinkHandle {
     ///
     /// The timer task rewinds `Q = A` and waits for a fresh write half.
     /// No-op when uncapped.
+    #[cfg(feature = "test-hooks")]
     pub fn notify_link_down(&self) {
         if let Some(tx) = &self.link_down_tx {
             let _ = tx.try_send(RateCmd::LinkDown);
@@ -404,6 +407,7 @@ impl ActiveStream {
             Arc::clone(&spool),
             Arc::clone(&q_atomic),
         );
+        #[cfg(feature = "test-hooks")]
         let link_down_tx = rate_limiter.link_down_tx_clone();
 
         let handle = UplinkHandle {
@@ -412,6 +416,7 @@ impl ActiveStream {
             spool: Arc::clone(&spool),
             info: info.clone(),
             priority,
+            #[cfg(feature = "test-hooks")]
             link_down_tx,
         };
 

--- a/quelay-agent/src/agent.rs
+++ b/quelay-agent/src/agent.rs
@@ -55,8 +55,9 @@ impl Agent {
                         .await;
                 }
 
+                #[cfg(feature = "test-hooks")]
                 AgentCmd::LinkEnable(enabled) => {
-                    // Forward LE to SessionManagerHandle
+                    // Forward to SessionManager via command channel
                     let _ = self
                         .sm_cmd_tx
                         .send(SessionCommand::LinkEnable(enabled))
@@ -67,6 +68,7 @@ impl Agent {
                 // this command is sent.  The session manager reads the new
                 // value on the next stream_start; no further action needed
                 // here beyond the log line.
+                #[cfg(feature = "test-hooks")]
                 AgentCmd::SetMaxConcurrent(n) => {
                     tracing::info!(n, "set_max_concurrent (test/debug)");
                     // n == 0 means "restore default / unlimited"; propagate as None.

--- a/quelay-agent/src/main.rs
+++ b/quelay-agent/src/main.rs
@@ -71,7 +71,7 @@ use session_manager::{
     TransportConfig,
 };
 
-use thrift_srv::{AgentHandler, RuntimeConfig, StreamStartResponse};
+pub use thrift_srv::{AgentCmd, AgentHandler, RuntimeConfig, StreamStartResponse};
 
 // Gateway re-exports — siblings import via super::Symbol per EMBP §2.3
 pub(crate) use active_stream::{
@@ -86,9 +86,11 @@ pub(crate) use rate_limiter::{
     // --
     AggregateRateLimiter,
     AllocTicket,
-    RateCmd,
     RateLimiter,
 };
+
+#[cfg(feature = "test-hooks")]
+pub(crate) use rate_limiter::RateCmd;
 
 pub use callback::{CallbackCmd, CallbackTx};
 pub use framing::{
@@ -109,7 +111,6 @@ pub use framing::{
     CHUNK_HEADER_LEN,
     CHUNK_SIZE,
 };
-pub(crate) use thrift_srv::AgentCmd;
 
 // ---------------------------------------------------------------------------
 // main

--- a/quelay-agent/src/rate_limiter.rs
+++ b/quelay-agent/src/rate_limiter.rs
@@ -765,6 +765,7 @@ impl RateLimiter {
 
     /// Return a clone of `cmd_tx` so `UplinkHandle` can send `LinkDown`.
     /// Returns `None` in uncapped mode.
+    #[cfg(feature = "test-hooks")]
     pub fn link_down_tx_clone(&self) -> Option<mpsc::Sender<RateCmd>> {
         self.cmd_tx.clone()
     }

--- a/quelay-agent/src/session_manager.rs
+++ b/quelay-agent/src/session_manager.rs
@@ -81,7 +81,10 @@ pub(crate) enum SessionCommand {
     },
     /// Update the maximum number of concurrent active uplinks at runtime.
     /// `None` means unlimited (0 from the C2I layer maps to this).
+    #[cfg(feature = "test-hooks")]
     SetMaxConcurrent(Option<usize>),
+
+    #[cfg(feature = "test-hooks")]
     LinkEnable(bool),
 }
 
@@ -536,6 +539,7 @@ impl SessionManager {
                 }
             }
 
+            #[cfg(feature = "test-hooks")]
             SessionCommand::SetMaxConcurrent(new_limit) => {
                 tracing::debug!(?new_limit, "set_max_concurrent: updating session manager");
                 let mut guard = self.remote.lock().await;
@@ -552,6 +556,7 @@ impl SessionManager {
                     remote.send_queue_status(&self.cb_tx).await;
                 }
             }
+            #[cfg(feature = "test-hooks")]
             SessionCommand::LinkEnable(enable) => self.link_enable(enable).await,
         }
     }
@@ -781,6 +786,7 @@ impl SessionManager {
     ///
     /// When `true`: no-op — `restore_active` calls `link_up` after the
     /// reconnect loop delivers fresh streams.
+    #[cfg(feature = "test-hooks")]
     async fn link_enable(&self, enabled: bool) {
         // ---
         tracing::info!(enabled, "link_enable");

--- a/quelay-agent/src/thrift_srv.rs
+++ b/quelay-agent/src/thrift_srv.rs
@@ -41,7 +41,38 @@ use super::{
 // ---
 
 use super::{CallbackCmd, CallbackTx};
+#[cfg(feature = "test-hooks")]
 use crate::config::{DEFAULT_CHUNK_SIZE_BYTES, DEFAULT_MAX_CONCURRENT};
+
+// ---------------------------------------------------------------------------
+// test_hook! macro
+// ---------------------------------------------------------------------------
+
+/// Gate a test/debug RPC handler body behind the `test-hooks` feature.
+///
+/// Usage:
+/// ```ignore
+/// fn handle_foo(&self, ...) -> thrift::Result<()> {
+///     test_hook!({
+///         // body only compiled and executed when test-hooks is enabled
+///         self.send_cmd(AgentCmd::Foo)
+///     })
+/// }
+/// ```
+///
+/// When `test-hooks` is disabled the macro expands to `Ok(())` and the
+/// body is excluded entirely from the production binary.
+macro_rules! test_hook {
+    ($expr:expr) => {{
+        #[cfg(feature = "test-hooks")]
+        return $expr;
+        #[cfg(not(feature = "test-hooks"))]
+        {
+            tracing::warn!("test-hooks feature is disabled; call ignored");
+            Ok(())
+        }
+    }};
+}
 
 // ---------------------------------------------------------------------------
 // RuntimeConfig
@@ -146,10 +177,12 @@ pub enum AgentCmd {
 
     /// Test/debug only — enable or disable the QUIC link.
     /// Must not be exposed in production builds.
+    #[cfg(feature = "test-hooks")]
     LinkEnable(bool),
 
     /// Test/debug only — update the max-concurrent limit in the scheduler.
     /// Must not be exposed in production builds.
+    #[cfg(feature = "test-hooks")]
     SetMaxConcurrent(usize),
 }
 
@@ -338,55 +371,58 @@ impl QueLayAgentSyncHandler for AgentHandler {
     // Test / debug handlers — disabled in production builds
     // -----------------------------------------------------------------------
 
-    fn handle_link_enable(&self, enabled: bool) -> thrift::Result<()> {
+    fn handle_link_enable(&self, _enabled: bool) -> thrift::Result<()> {
         // ---
-
-        tracing::info!(enabled, "link_enable (test/debug)");
-        self.send_cmd(AgentCmd::LinkEnable(enabled))
+        test_hook!({
+            tracing::info!(enabled = _enabled, "link_enable (test/debug)");
+            self.send_cmd(AgentCmd::LinkEnable(_enabled))
+        })
     }
 
     // ---
 
-    fn handle_set_max_concurrent(&self, n: i32) -> thrift::Result<()> {
+    fn handle_set_max_concurrent(&self, _n: i32) -> thrift::Result<()> {
         // ---
+        test_hook!({
+            let n = _n as usize;
+            tracing::warn!(n, "set_max_concurrent (test/debug)");
 
-        let n = n as usize;
-        tracing::warn!(n, "set_max_concurrent (test/debug)");
+            {
+                let mut cfg = self.lock_runtime_cfg()?;
+                cfg.max_concurrent = if n == 0 { DEFAULT_MAX_CONCURRENT } else { n };
+            }
 
-        {
-            let mut cfg = self.lock_runtime_cfg()?;
-            cfg.max_concurrent = if n == 0 { DEFAULT_MAX_CONCURRENT } else { n };
-        }
-
-        self.send_cmd(AgentCmd::SetMaxConcurrent(n))
+            self.send_cmd(AgentCmd::SetMaxConcurrent(n))
+        })
     }
 
     // ---
 
-    fn handle_set_chunk_size_bytes(&self, n: i32) -> thrift::Result<()> {
+    fn handle_set_chunk_size_bytes(&self, _n: i32) -> thrift::Result<()> {
         // ---
+        test_hook!({
+            let requested = _n as usize;
+            tracing::debug!(requested, "set_chunk_size_bytes (test/debug)");
 
-        let requested = n as usize;
-        tracing::debug!(requested, "set_chunk_size_bytes (test/debug)");
+            let effective = if requested == 0 {
+                DEFAULT_CHUNK_SIZE_BYTES
+            } else {
+                requested
+            };
 
-        let effective = if requested == 0 {
-            DEFAULT_CHUNK_SIZE_BYTES
-        } else {
-            requested
-        };
+            if effective > 65_535 {
+                return Err(thrift::Error::Application(thrift::ApplicationError::new(
+                    thrift::ApplicationErrorKind::InvalidTransform,
+                    format!("chunk_size_bytes {effective} exceeds u16 max (65535)"),
+                )));
+            }
 
-        if effective > 65_535 {
-            return Err(thrift::Error::Application(thrift::ApplicationError::new(
-                thrift::ApplicationErrorKind::InvalidTransform,
-                format!("chunk_size_bytes {effective} exceeds u16 max (65535)"),
-            )));
-        }
+            {
+                let mut cfg = self.lock_runtime_cfg()?;
+                cfg.chunk_size_bytes = effective;
+            }
 
-        {
-            let mut cfg = self.lock_runtime_cfg()?;
-            cfg.chunk_size_bytes = effective;
-        }
-
-        Ok(())
+            Ok(())
+        })
     }
 }

--- a/scripts/ci-integration-test.sh
+++ b/scripts/ci-integration-test.sh
@@ -44,7 +44,7 @@ echo "==> Building workspace..."
 cd "$WORKSPACE"
 rm -f "$CERT_SRC" "$CERT_FILE"
 
-cargo build --bin quelay-agent --bin e2e-test
+cargo build --features test-hooks --bin quelay-agent --bin e2e-test
 
 AGENT_BIN="$TARGET_DIR/debug/quelay-agent"
 E2E_BIN="$TARGET_DIR/debug/e2e-test"


### PR DESCRIPTION
Add optional Cargo feature `test-hooks` (default disabled) that controls compilation of the three debug RPC handlers (link_enable, set_max_concurrent, set_chunk_size_bytes) and their supporting code: SessionCommand::LinkEnable, SessionCommand::SetMaxConcurrent, UplinkHandle::notify_link_down, and link_down_tx.

Production builds (`cargo build --release`) exclude all hook code. CI integration tests pass `--features test-hooks` explicitly via ci-integration-test.sh so the link-outage and DRR test scenarios remain fully exercised.